### PR TITLE
Include valid proposals sent during the current epoch with a GroupInfo response

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1514,9 +1514,9 @@ struct {
 } GroupInfoRequest;
 ~~~
 
-If successful, the response body contains the GroupInfo and a way
-to get the ratchet_tree, both encrypted with the `groupInfoPublcKey`
-passed in the request.
+If successful, the response body contains the GroupInfo, a way to get the
+`ratchet_tree`, and a list of any pending proposals for the epoch, all
+encrypted with the `groupInfoPublcKey` passed in the request.
 
 ~~~ tls
 enum {
@@ -1528,8 +1528,16 @@ enum {
 } GroupInfoCode;
 
 struct {
+    MLSMessage proposal;
+    uint64 hub_accepted_time;
+} PendingProposal;
+
+struct {
   GroupInfo groupInfo;   /* without embedded ratchet_tree */
   RatchetTreeOption ratchetTreeOption;
+  /* A list of valid pending proposals accepted by the hub */
+  /* during the current epoch                              */
+  PendingProposal pending_proposals<V>;
 } GroupInfoRatchetTreeTBE;
 
 GroupInfoRatchetTreeTBE group_info_ratchet_tree_tbe;


### PR DESCRIPTION
The MLS group for a room is in epoch <n>. 

Valid SelfRemove proposals are received from a member, or Valid AppDataUpdate or AppEphemeral external proposals are received from an external_sender.

The hub needs to provide these valid pending proposals which would be included in an external commit.