### PR TITLE
More franking fixes

### DIFF
--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1873,8 +1873,8 @@ abuse, and the `note` is a UTF8 human-readable string, which can be empty.
 
 Finally, abuse reports can optionally contain a handful of allegedly
 `AbusiveMessage`s, each of which contains an allegedly abusive
-`message_content`, its `server_frank`, its `franking_integrity_signature`, and
-its `accepted_timestamp`.
+`message_content`, its `server_frank`, its `franking_signature_ciphersuite`,
+its `franking_integrity_signature`, and its `accepted_timestamp`.
 
 ~~~ tls
 struct {
@@ -1899,12 +1899,15 @@ struct {
 } AbuseReport;
 ~~~
 
-There is no response body. The response code only indicates if the abuse report was accepted, not if any specific automated or human action was taken.
+There is no response body. The response code only indicates if the abuse report
+was accepted, not if any specific automated or human action was taken.
 
 To validate an allegedly AbusiveMessage, the hub finds the salt, sender URI, and
 room URI inside the `message_content` and the `accepted_timestamp` to
 recalculate the `franking_tag` and `context`. Then the hub selects its relevant
-`hub_key` to regenerate the `server_frank`. Finally the hub verifies its `franking_integrity_signature`.
+`hub_key` to regenerate the `server_frank`. Finally the hub verifies its
+`franking_integrity_signature` using the signature algorithm embedded in the
+`franking_signature_ciphersuite`.
 
 
 ## Download Files

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -223,9 +223,11 @@ in the MIMI protocol.  The scenario involves the following actors:
 
 * Service providers `a.example`, `b.example`, and `c.example` represented by
   servers `ServerA`, `ServerB`, and `ServerC` respectively
-* Users Alice (`alice`), Bob (`bob`) and Cathy (`cathy`) of the service providers `a.example`, `b.example`, and `c.example` respectively.
+* Users Alice (`alice`), Bob (`bob`) and Cathy (`cathy`) of the service
+  providers `a.example`, `b.example`, and `c.example` respectively.
 * Clients `ClientA1`, `ClientA2`, `ClientB1`, etc. belonging to these users
-* A room `clubhouse` hosted by hub provider `a.example` where the three users interact.
+* A room `clubhouse` hosted by hub provider `a.example` where the three users
+  interact.
 
 Inside the protocol, each provider is represented by a domain name in the
 `host` production of the `authority` of a MIMI URI {{!RFC3986}}. Specific
@@ -1790,7 +1792,8 @@ struct {
 ~~~
 
 The semantics of the `SearchIdentifierType` values are as follows. `handle`
-means that the entire handle URI matches exactly (for example: `im:alice.smith@a.example`). `nick` means that the nickname or handle
+means that the entire handle URI matches exactly (for example:
+`im:alice.smith@a.example`). `nick` means that the nickname or handle
 user part matches exactly (for example: `alice.smith`). The same account or
 human user may have multiple values which all match the `nick` field. `email`
 means the `addr-spec` production from {{!RFC5322}} matches the query string
@@ -1961,7 +1964,8 @@ other two methods.
 Without any additional MIMI protocol mechanism, MIMI clients can download assets
 directly from the asset provider. Unfortunately this usually reveals sensitive
 private information about the client. In this case, the asset provider learns
-the IP address of the client, and timing information about when assets are downloaded, which is strongly linked with online presence. The asset provider
+the IP address of the client, and timing information about when assets are
+downloaded, which is strongly linked with online presence. The asset provider
 can correlate other clients downloading the same assets and infer which clients
 are in which rooms. For this reason, direct client downloads of assets,
 especially from an asset provider which is not the download client's provider,

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1267,7 +1267,7 @@ franking_integrity_signature =
 
 The `sender_length_uint16` and `room_length_unit16` are each a 16-bit unsigned
 integer length field in network order. Prepending the length before the URIs
-in the context prevents a class of attacks which could occur if room URIs and
+in the context prevents a class of attacks, which could occur if room URIs and
 sender URIs were created maliciously.
 
 `hub_key` is a secret symmetric key used on the Hub which the Hub can use to

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1116,7 +1116,7 @@ enum {
 
 struct {
   uint8 server_frank[32];
-  uint16 franking_signature_ciphersuite;
+  CipherSuite franking_signature_ciphersuite;
   opaque franking_integrity_signature<V>;
 } Frank;
 

--- a/draft-ietf-mimi-protocol.md
+++ b/draft-ietf-mimi-protocol.md
@@ -1173,7 +1173,7 @@ contains a single signature key.
 
 ~~~ tls
 struct {
-  uint8[32] franking_tag
+  uint8 franking_tag[32];
 } FrankAAD;
 
 FrankAAD frank_aad;
@@ -1232,6 +1232,10 @@ and cannot later deny to a receiver that it sent them.
 Then the client calculates the `franking_tag`, as the HMAC SHA256 of the
 `application_data` (which includes the values in the extensions map above)
 using the `salt` in the MIMI content format:
+
+> Note that when the content advertisement mechanism in {Section 6.2 of
+> !I-D.ietf-mls-extensions} is used, the `application_data` includes the
+> `media_type` in the `ApplicationFraming` struct.
 
 ~~~
 franking_tag = HMAC_SHA256( salt, application_data)


### PR DESCRIPTION
- Added an explicit (uint16) lengths for the sender URI and room URI in the franking context. Addresses #122 
- Added a `franking_signature_ciphersuite` to allow the hub to validate a `franking_integrity_signature` even after the MLS ciphersuite has changed in that room. Addresses #129 